### PR TITLE
Add Flask Todo app backed by Google Cloud Datastore

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
-# demo_cloud_computin_webside.
+# Cloud Todo List Demo
+
+Ứng dụng Todo List tối giản minh họa cách sử dụng Google Cloud Datastore với Flask/Python.
+
+## Tính năng chính
+
+- Tạo, xem, cập nhật và xóa các công việc (CRUD).
+- Lưu trữ dữ liệu trên Datastore theo mô hình NoSQL (Entity/Kind/Property).
+- Giao diện web đơn giản sử dụng Bootstrap.
+
+## Cấu hình môi trường
+
+1. Cài đặt Python 3.10+ và `pip`.
+2. Sao chép file khóa dịch vụ Google Cloud (JSON) và đặt đường dẫn vào biến môi trường `GOOGLE_APPLICATION_CREDENTIALS`.
+3. Đặt biến môi trường `GOOGLE_CLOUD_PROJECT` tương ứng với project ID của bạn.
+4. (Tùy chọn) Đặt `FLASK_SECRET_KEY` để cấu hình secret key cho Flask.
+
+Ví dụ trên Linux/macOS:
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/service-account.json"
+export GOOGLE_CLOUD_PROJECT="your-project-id"
+export FLASK_SECRET_KEY="super-secret"
+```
+
+## Cài đặt phụ thuộc
+
+```bash
+pip install -r requirements.txt
+```
+
+## Chạy ứng dụng local
+
+```bash
+export FLASK_APP=app.py
+flask run --host=0.0.0.0 --port=8080
+```
+
+Ứng dụng sẽ chạy tại `http://localhost:8080`. Bạn có thể tạo mới, chỉnh sửa hoặc xóa công việc trực tiếp trên giao diện.
+
+## Triển khai nhanh lên Google Cloud Run
+
+1. Đảm bảo Google Cloud SDK đã được cài đặt và cấu hình project.
+2. Xây dựng image và deploy:
+
+```bash
+gcloud builds submit --tag gcr.io/$GOOGLE_CLOUD_PROJECT/cloud-todo-demo
+gcloud run deploy cloud-todo-demo \
+  --image gcr.io/$GOOGLE_CLOUD_PROJECT/cloud-todo-demo \
+  --platform managed \
+  --allow-unauthenticated
+```
+
+Ứng dụng sẽ tự động lấy thông tin chứng thực từ môi trường khi chạy trên Cloud Run/App Engine.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,114 @@
+import os
+from datetime import datetime
+from typing import Optional
+
+from flask import Flask, redirect, render_template, request, url_for, flash
+from google.cloud import datastore
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+    app.config["SECRET_KEY"] = os.environ.get("FLASK_SECRET_KEY", "change-me")
+
+    project_id = os.environ.get("GOOGLE_CLOUD_PROJECT")
+    if not project_id:
+        raise RuntimeError("Missing GOOGLE_CLOUD_PROJECT environment variable")
+
+    client = datastore.Client(project=project_id)
+
+    KIND = "Task"
+
+    def entity_to_dict(entity: datastore.Entity) -> dict:
+        return {
+            "id": entity.key.id,
+            "title": entity.get("title", ""),
+            "description": entity.get("description", ""),
+            "status": entity.get("status", "pending"),
+            "created_at": entity.get("created_at"),
+        }
+
+    @app.route("/")
+    def index():
+        query = client.query(kind=KIND)
+        query.order = ["-created_at"]
+        tasks = [entity_to_dict(entity) for entity in query.fetch()]
+        return render_template("index.html", tasks=tasks)
+
+    @app.route("/tasks", methods=["POST"])
+    def create_task():
+        title = request.form.get("title", "").strip()
+        description = request.form.get("description", "").strip()
+        status = request.form.get("status", "pending")
+
+        if not title:
+            flash("Title is required.", "error")
+            return redirect(url_for("index"))
+
+        key = client.key(KIND)
+        entity = datastore.Entity(key=key)
+        entity.update(
+            {
+                "title": title,
+                "description": description,
+                "status": status,
+                "created_at": datetime.utcnow(),
+            }
+        )
+        client.put(entity)
+        flash("Task created successfully!", "success")
+        return redirect(url_for("index"))
+
+    def get_task_or_404(task_id: int) -> Optional[datastore.Entity]:
+        key = client.key(KIND, task_id)
+        entity = client.get(key)
+        if entity is None:
+            flash("Task not found.", "error")
+        return entity
+
+    @app.route("/tasks/<int:task_id>/edit")
+    def edit_task(task_id: int):
+        entity = get_task_or_404(task_id)
+        if entity is None:
+            return redirect(url_for("index"))
+        task = entity_to_dict(entity)
+        return render_template("edit.html", task=task)
+
+    @app.route("/tasks/<int:task_id>", methods=["POST"])
+    def update_task(task_id: int):
+        entity = get_task_or_404(task_id)
+        if entity is None:
+            return redirect(url_for("index"))
+
+        title = request.form.get("title", "").strip()
+        description = request.form.get("description", "").strip()
+        status = request.form.get("status", "pending")
+
+        if not title:
+            flash("Title is required.", "error")
+            return redirect(url_for("edit_task", task_id=task_id))
+
+        entity.update(
+            {
+                "title": title,
+                "description": description,
+                "status": status,
+            }
+        )
+        client.put(entity)
+        flash("Task updated successfully!", "success")
+        return redirect(url_for("index"))
+
+    @app.route("/tasks/<int:task_id>/delete", methods=["POST"])
+    def delete_task(task_id: int):
+        key = client.key(KIND, task_id)
+        client.delete(key)
+        flash("Task deleted.", "info")
+        return redirect(url_for("index"))
+
+    return app
+
+
+app = create_app()
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 8080)), debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask==3.0.3
+google-cloud-datastore==2.19.0

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{% block title %}Cloud Todo List{% endblock %}</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+      crossorigin="anonymous"
+    />
+  </head>
+  <body class="bg-light">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
+      <div class="container">
+        <span class="navbar-brand">Cloud Todo List</span>
+      </div>
+    </nav>
+    <main class="container">
+      {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+      <div class="mb-3">
+        {% for category, message in messages %}
+        <div class="alert alert-{{ 'danger' if category == 'error' else category }}" role="alert">
+          {{ message }}
+        </div>
+        {% endfor %}
+      </div>
+      {% endif %}
+      {% endwith %}
+
+      {% block content %}{% endblock %}
+    </main>
+  </body>
+</html>

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% block title %}Edit Task{% endblock %}
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-lg-6">
+    <div class="card shadow-sm">
+      <div class="card-body">
+        <h2 class="h5 mb-3">Edit task</h2>
+        <form method="post" action="{{ url_for('update_task', task_id=task.id) }}">
+          <div class="mb-3">
+            <label for="title" class="form-label">Title</label>
+            <input type="text" class="form-control" id="title" name="title" value="{{ task.title }}" required />
+          </div>
+          <div class="mb-3">
+            <label for="description" class="form-label">Description</label>
+            <textarea class="form-control" id="description" name="description" rows="4">{{ task.description }}</textarea>
+          </div>
+          <div class="mb-3">
+            <label for="status" class="form-label">Status</label>
+            <select class="form-select" id="status" name="status">
+              <option value="pending" {% if task.status == 'pending' %}selected{% endif %}>Pending</option>
+              <option value="done" {% if task.status == 'done' %}selected{% endif %}>Done</option>
+            </select>
+          </div>
+          <div class="d-flex gap-2">
+            <button type="submit" class="btn btn-primary">Save changes</button>
+            <a class="btn btn-outline-secondary" href="{{ url_for('index') }}">Cancel</a>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,60 @@
+{% extends "base.html" %}
+{% block title %}Todo List{% endblock %}
+{% block content %}
+<div class="row">
+  <div class="col-lg-5 mb-4">
+    <div class="card shadow-sm">
+      <div class="card-body">
+        <h2 class="h5 mb-3">Add a new task</h2>
+        <form method="post" action="{{ url_for('create_task') }}">
+          <div class="mb-3">
+            <label for="title" class="form-label">Title</label>
+            <input type="text" class="form-control" id="title" name="title" required />
+          </div>
+          <div class="mb-3">
+            <label for="description" class="form-label">Description</label>
+            <textarea class="form-control" id="description" name="description" rows="3"></textarea>
+          </div>
+          <div class="mb-3">
+            <label for="status" class="form-label">Status</label>
+            <select class="form-select" id="status" name="status">
+              <option value="pending" selected>Pending</option>
+              <option value="done">Done</option>
+            </select>
+          </div>
+          <button type="submit" class="btn btn-primary">Create task</button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div class="col-lg-7">
+    <div class="card shadow-sm">
+      <div class="card-body">
+        <h2 class="h5 mb-3">Tasks</h2>
+        {% if tasks %}
+        <div class="list-group">
+          {% for task in tasks %}
+          <div class="list-group-item list-group-item-action mb-2">
+            <div class="d-flex w-100 justify-content-between">
+              <h3 class="h6 mb-1">{{ task.title }}</h3>
+              <small class="text-muted">{{ task.created_at.strftime('%Y-%m-%d %H:%M:%S') if task.created_at }}</small>
+            </div>
+            <p class="mb-2">{{ task.description or 'No description' }}</p>
+            <div class="d-flex align-items-center gap-2">
+              <span class="badge bg-{{ 'success' if task.status == 'done' else 'warning text-dark' }} text-uppercase">{{ task.status }}</span>
+              <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('edit_task', task_id=task.id) }}">Edit</a>
+              <form method="post" action="{{ url_for('delete_task', task_id=task.id) }}" onsubmit="return confirm('Delete this task?');">
+                <button type="submit" class="btn btn-sm btn-outline-danger">Delete</button>
+              </form>
+            </div>
+          </div>
+          {% endfor %}
+        </div>
+        {% else %}
+        <p class="text-muted">No tasks yet. Add one above!</p>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a Flask application that performs CRUD operations on Google Cloud Datastore entities for todo tasks
- create Bootstrap-based templates for listing, creating, and editing tasks
- document setup instructions and dependencies for running locally or on Cloud Run

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68d5eec45790832fad16521e2cafdda6